### PR TITLE
fix: set Vite base path for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
       - name: Typecheck
         run: npm run typecheck
 
@@ -39,6 +43,7 @@ jobs:
         run: npm run build
         env:
           VITE_GOOGLE_CALENDAR_API_KEY: ${{ secrets.GCAL_API_KEY }}
+          VITE_BASE_PATH: ${{ steps.pages.outputs.base_path }}/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import './styles/global.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <App />
     </BrowserRouter>
   </StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,5 @@ import { defineConfig } from "vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  base: process.env.VITE_BASE_PATH ?? "/",
 });


### PR DESCRIPTION
## Summary

Fixes the blank page / 404 on the live GitHub Pages site.

GitHub Pages serves the site from `https://allen-ml.github.io/USC-AI_GenerativeAI_NLP/` but Vite was building all asset paths relative to `/`, so every JS/CSS file returned 404.

## Changes

- **`vite.config.ts`** — read `base` from `VITE_BASE_PATH` env var (defaults to `/` for local dev)
- **`deploy.yml`** — run `actions/configure-pages` before the build step so its `base_path` output (`/USC-AI_GenerativeAI_NLP`) is available; pass it as `VITE_BASE_PATH` to the build
- **`src/main.tsx`** — set `BrowserRouter basename={import.meta.env.BASE_URL}` so React Router links resolve correctly under the subpath

Local dev is unaffected — `VITE_BASE_PATH` is unset locally so `base` stays `/`.

## Test plan

- [ ] Merge and wait for the Publish workflow to complete
- [ ] Visit `https://allen-ml.github.io/USC-AI_GenerativeAI_NLP/` — site loads
- [ ] Navigate between routes — no 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)