### PR TITLE
fix: resolve public asset paths for GitHub Pages subpath

### DIFF
--- a/src/archive/components/ProjectCard/PlaceholderCard.tsx
+++ b/src/archive/components/ProjectCard/PlaceholderCard.tsx
@@ -1,11 +1,12 @@
 import React from "react";
+import { publicUrl } from "../../../utils/config";
 
 const PlaceholderCard: React.FC = () => {
   return (
     <div className="col-lg-4 col-md-6 col-sm-12">
       <div className="project-card">
         <img
-          src="/archive/tbp.png"
+          src={publicUrl("/archive/tbp.png")}
           className="project-image d-block w-100"
           alt="To be published"
         />

--- a/src/archive/components/ProjectCard/ProjectCard.tsx
+++ b/src/archive/components/ProjectCard/ProjectCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { Project } from "../../types/ProjectTypes";
+import { publicUrl } from "../../../utils/config";
 
 interface ProjectCardProps {
   project: Project;
@@ -78,7 +79,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
           )
         ) : (
           <img
-            src="/archive/tbp.png"
+            src={publicUrl("/archive/tbp.png")}
             className="project-image d-block w-100"
             alt="To be published"
           />

--- a/src/archive/pages/Fall2024/Fall2024.tsx
+++ b/src/archive/pages/Fall2024/Fall2024.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import fall2024Data from "../../content/fall-2024.json";
 import type { Fall2024ContentFormat } from "../../types/ContentTypes";
+import { publicUrl } from "../../../utils/config";
 import styles from "./Fall2024.module.css";
 
 const Fall2024: React.FC = () => {
@@ -37,7 +38,7 @@ const Fall2024: React.FC = () => {
         {/* Banner */}
         <div className={styles.banner}>
           <img
-            src="/usc-logo.png"
+            src={publicUrl("/usc-logo.png")}
             alt="USC Logo"
             className={styles.bannerImg}
           />
@@ -76,7 +77,7 @@ const Fall2024: React.FC = () => {
               <h4>{staffMember.title}</h4>
               <div className={index === 0 ? styles.instructor : styles.ta}>
                 <img
-                  src={staffMember.profilePicture || "/usc-logo.png"}
+                  src={publicUrl(staffMember.profilePicture || "/usc-logo.png")}
                   alt={`${staffMember.title} Photo`}
                   className={index === 0 ? styles.instructorImg : styles.taImg}
                 />

--- a/src/archive/pages/Spring2024/Spring2024.module.css
+++ b/src/archive/pages/Spring2024/Spring2024.module.css
@@ -64,7 +64,7 @@
 .imageRepeatTop {
   width: 100%; /* Full width */
   height: 200px; /* Height of the repeating area */
-  background-image: url("/archive/GenAI_Image_small.png"); /* Path to your image */
+  /* background-image set via inline style in Spring2024.tsx using publicUrl() */
   background-repeat: repeat-x; /* Repeat horizontally */
   background-position: top center; /* Align the background image to the top center */
 }

--- a/src/archive/pages/Spring2024/Spring2024.tsx
+++ b/src/archive/pages/Spring2024/Spring2024.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import spring2024Data from "../../content/spring-2024.json";
 import type { Spring2024ContentFormat } from "../../types/ContentTypes";
+import { publicUrl } from "../../../utils/config";
 import styles from "./Spring2024.module.css";
 
 const Spring2024: React.FC = () => {
@@ -59,7 +60,10 @@ const Spring2024: React.FC = () => {
   return (
     <div className={styles.body}>
       <div className={styles.contentWrapper}>
-        <div className={styles.imageRepeatTop}></div>
+        <div
+          className={styles.imageRepeatTop}
+          style={{ backgroundImage: `url(${publicUrl("/archive/GenAI_Image_small.png")})` }}
+        ></div>
         <h1>{data.title}</h1>
         <h2>{data.subtitle}</h2>
         <p className={styles.courseInfo}>
@@ -102,7 +106,7 @@ const Spring2024: React.FC = () => {
             </a>
             <br />
             <img
-              src={assistant.profilePicture || "/usc-logo.png"}
+              src={publicUrl(assistant.profilePicture || "/usc-logo.png")}
               alt="Course Assistant"
               className={styles.assistantImage}
             />

--- a/src/archive/pages/Spring2025/Spring2025.tsx
+++ b/src/archive/pages/Spring2025/Spring2025.tsx
@@ -3,6 +3,7 @@ import { ExpandableTopics } from "../../components/ExpandableTopics/ExpandableTo
 import spring2025Data from "../../content/spring-2025.json";
 import { Spring2025Layout } from "../../layouts/Spring2025Layout/Spring2025Layout";
 import type { Spring2025ContentFormat } from "../../types/ContentTypes";
+import { publicUrl } from "../../../utils/config";
 import styles from "./Spring2025.module.css";
 
 const Spring2025: React.FC = () => {
@@ -48,7 +49,7 @@ const Spring2025: React.FC = () => {
                 <div key={index} className="col-md-6 mb-3">
                   <div className="text-center p-3">
                     <img
-                      src={instructor.profilePicture}
+                      src={publicUrl(instructor.profilePicture ?? "/usc-logo.png")}
                       alt={instructor.name}
                       className={`${styles.fixedImage} rounded-circle mb-3`}
                     />
@@ -80,7 +81,7 @@ const Spring2025: React.FC = () => {
                 <div key={index} className="col-md-4 mb-3">
                   <div className="text-center p-3">
                     <img
-                      src={assistant.profilePicture}
+                      src={publicUrl(assistant.profilePicture ?? "/usc-logo.png")}
                       alt={assistant.name}
                       className={`${styles.fixedImage} rounded-circle mb-3`}
                     />

--- a/src/pages/alumni/Alumni.tsx
+++ b/src/pages/alumni/Alumni.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { allPastSemesters, type AlumniPerson, type SemesterAlumni } from '../../content/past-instructors/index';
+import { publicUrl } from '../../utils/config';
 import styles from './Alumni.module.css';
 
 interface PersonCardProps {
@@ -13,11 +14,11 @@ const PersonCard: React.FC<PersonCardProps> = ({ person }) => {
     <div className={styles.personCard}>
       <div className={styles.avatarWrapper}>
         <img
-          src={`/people/${person.Image}`}
+          src={publicUrl(`/people/${person.Image}`)}
           alt={person.Name}
           className={styles.avatar}
           onError={(e) => {
-            (e.target as HTMLImageElement).src = '/usc-logo.png';
+            (e.target as HTMLImageElement).src = publicUrl('/usc-logo.png');
           }}
         />
       </div>

--- a/src/pages/credits/Credits.tsx
+++ b/src/pages/credits/Credits.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { publicUrl } from '../../utils/config';
 import styles from './Credits.module.css';
 
 const Credits: React.FC = () => {
@@ -47,7 +48,7 @@ const Credits: React.FC = () => {
         <a href="https://github.com/arvinduh" target="_blank" rel="noopener noreferrer">
           <img
             ref={githubLogoRef}
-            src="/github-mark-white.svg"
+            src={publicUrl("/github-mark-white.svg")}
             alt="GitHub Profile"
             className={styles.githubLogo}
           />

--- a/src/pages/instructors/Instructors.tsx
+++ b/src/pages/instructors/Instructors.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import instructorsData from '../../content/instructors.json';
+import { publicUrl } from '../../utils/config';
 import styles from './Instructors.module.css';
 
 interface Instructor {
@@ -52,10 +53,10 @@ const InstructorCard: React.FC<InstructorCardProps> = ({ instructor }) => {
       <div className={styles.cardTop}>
         <div className={styles.avatarRing}>
           <img
-            src={`/people/${instructor.Image}`}
+            src={publicUrl(`/people/${instructor.Image}`)}
             alt={instructor.Name}
             className={styles.avatar}
-            onError={(e) => { (e.target as HTMLImageElement).src = '/usc-logo.png'; }}
+            onError={(e) => { (e.target as HTMLImageElement).src = publicUrl('/usc-logo.png'); }}
           />
         </div>
         <div className={styles.identity}>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,8 @@
+// Resolve a /public path against the Vite base so it works on GitHub Pages subpaths.
+// Usage: publicUrl('/people/allen.jpg') → '/USC-AI_GenerativeAI_NLP/people/allen.jpg'
+export const publicUrl = (path: string): string =>
+  `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
+
 export const getGoogleCalendarConfig = () => {
   return {
     apiKey: import.meta.env.VITE_GOOGLE_CALENDAR_API_KEY as string,


### PR DESCRIPTION
## Problem

All images on the deployed site were 404ing. GitHub Pages serves the site from `/USC-AI_GenerativeAI_NLP/` but every image was referenced with an absolute path like `/people/allen.jpg` — missing the subpath prefix.

## Fix

Added `publicUrl()` to `src/utils/config.ts`:

```ts
export const publicUrl = (path: string): string =>
  `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
```

`import.meta.env.BASE_URL` is Vite's built-in base path variable — `/USC-AI_GenerativeAI_NLP/` in production, `/` in local dev. This means local dev is unaffected.

## Files changed

| File | Fix |
|---|---|
| `src/utils/config.ts` | Add `publicUrl()` utility |
| `src/pages/instructors/Instructors.tsx` | People photos + fallback |
| `src/pages/alumni/Alumni.tsx` | People photos + fallback |
| `src/pages/credits/Credits.tsx` | GitHub logo |
| `src/archive/pages/Fall2024/Fall2024.tsx` | USC logo + staff photos |
| `src/archive/pages/Spring2024/Spring2024.tsx` | Staff photos |
| `src/archive/pages/Spring2024/Spring2024.module.css` | Move background-image to inline style (CSS `url()` can't access `import.meta.env`) |
| `src/archive/pages/Spring2025/Spring2025.tsx` | Staff photos |
| `src/archive/components/ProjectCard/ProjectCard.tsx` | TBP placeholder |
| `src/archive/components/ProjectCard/PlaceholderCard.tsx` | TBP placeholder |

🤖 Generated with [Claude Code](https://claude.com/claude-code)