### PR TITLE
fix: stop onError 404 loop, fix project carousel image paths

### DIFF
--- a/src/archive/components/ProjectCard/ProjectCard.tsx
+++ b/src/archive/components/ProjectCard/ProjectCard.tsx
@@ -38,11 +38,12 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
                     }`}
                   >
                     <img
-                      src={image}
+                      src={publicUrl(image)}
                       className="project-image d-block w-100"
                       alt={`${project.title || `Project ${index + 1}`} Image ${
                         imgIndex + 1
                       }`}
+                      onError={(e) => { const img = e.target as HTMLImageElement; img.onerror = null; img.src = publicUrl("/archive/tbp.png"); }}
                     />
                   </div>
                 ))}

--- a/src/pages/alumni/Alumni.tsx
+++ b/src/pages/alumni/Alumni.tsx
@@ -18,7 +18,9 @@ const PersonCard: React.FC<PersonCardProps> = ({ person }) => {
           alt={person.Name}
           className={styles.avatar}
           onError={(e) => {
-            (e.target as HTMLImageElement).src = publicUrl('/usc-logo.png');
+            const img = e.target as HTMLImageElement;
+            img.onerror = null;
+            img.src = publicUrl('/usc-logo.png');
           }}
         />
       </div>

--- a/src/pages/instructors/Instructors.tsx
+++ b/src/pages/instructors/Instructors.tsx
@@ -56,7 +56,7 @@ const InstructorCard: React.FC<InstructorCardProps> = ({ instructor }) => {
             src={publicUrl(`/people/${instructor.Image}`)}
             alt={instructor.Name}
             className={styles.avatar}
-            onError={(e) => { (e.target as HTMLImageElement).src = publicUrl('/usc-logo.png'); }}
+            onError={(e) => { const img = e.target as HTMLImageElement; img.onerror = null; img.src = publicUrl('/usc-logo.png'); }}
           />
         </div>
         <div className={styles.identity}>


### PR DESCRIPTION
## Problems

**Infinite 404 loop:** `onError` sets a fallback `src` → fallback also 404s → `onError` fires again → repeat indefinitely.

**Project carousel images spamming 404s:** `src={image}` in `ProjectCard` was using raw JSON paths (absolute, missing the base prefix) with no `onError` fallback, so every missing project image fired repeated requests.

## Fix

**`img.onerror = null` before setting fallback src** — nulling the handler before changing `src` means it can only ever fire once per image element, regardless of whether the fallback loads.

**`publicUrl(image)` in ProjectCard carousel** — wraps the JSON path in the base-aware utility, same as the rest of the codebase.

## Files

| File | Change |
|---|---|
| `src/pages/instructors/Instructors.tsx` | `img.onerror = null` guard |
| `src/pages/alumni/Alumni.tsx` | `img.onerror = null` guard |
| `src/archive/components/ProjectCard/ProjectCard.tsx` | `publicUrl(image)` + guarded `onError` → tbp.png |

🤖 Generated with [Claude Code](https://claude.com/claude-code)